### PR TITLE
Add call to Fishbowl “LogoutRq” action when calling Logout method

### DIFF
--- a/FishbowlAPIJSON.php
+++ b/FishbowlAPIJSON.php
@@ -43,7 +43,7 @@ class FishbowlAPIJSON {
     public function Login($name, $pwd){
         if($this->_next == 'Login'){
             $this->_user = $name;
-            $this->_password = base64_encode(md5($pwd, true));
+            $this->_password = $pwd;
 
             $this->Request("LoginRq", [
                 "IAID"=>$this->_appKey,

--- a/FishbowlAPIJSON.php
+++ b/FishbowlAPIJSON.php
@@ -359,6 +359,7 @@ class FishbowlAPIJSON {
     }
 
     public function Logout(){
+        $this->Request("LogoutRq", "");
         fclose($this->_connection);
         $this->_next = 'SetHostInfo';
     }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ $fb = new FishbowlAPIJSON;
 $fb->SetHostInfo('IP or URL to Your Fishbowl API','Port for Your Fishbowl API');
 $fb->SetAppInfo("Your App name", "Your App ID", "Your App description");
 $fb->Login("Your username in Fishbowl","Your password in Fishbowl");
+$fb->Logout();
 ```
 ## query example:
 ```php 


### PR DESCRIPTION
A user session in Fishbowl will remain open unless the “logoutRq” action is executed in Fishbowl. This fix adds this call to the Logout method so that sessions are properly closed.